### PR TITLE
fix comparison in macex.c:112

### DIFF
--- a/aldor/aldor/src/foam.c
+++ b/aldor/aldor/src/foam.c
@@ -1188,7 +1188,7 @@ foamAuditTypeCheck(Foam foam)
 		lhs = foam->foamSet.lhs;
 		rhs = foam->foamSet.rhs;
 
-		if (!foamIsRef(lhs) && !foamTag(lhs) == FOAM_Values) {
+		if (!foamIsRef(lhs) && (foamTag(lhs) != FOAM_Values)) {
 			faTypeCheckingFailure(foam, "lhs is not an l-value");
 			return false;
 		}

--- a/aldor/aldor/src/foam_c.h
+++ b/aldor/aldor/src/foam_c.h
@@ -769,7 +769,7 @@ extern void		fiRegisterStateFns	(void *(*)(), void (*)(void *));
 	}							\
 	else {	/* should look for additional protects	*/	\
 		fiRestoreState(state);				\
-		if (!state->target == (FiWord) state) {		\
+		if (state->target != (FiWord) state) {		\
 			fiUnwind(state->target, state->value);	\
 		}						\
 		exn = state->value;				\
@@ -789,7 +789,7 @@ extern void		fiRegisterStateFns	(void *(*)(), void (*)(void *));
 	}							\
 	else {	/* should look for additional protects	*/	\
 		fiRestoreState(state);				\
-		if (!state->target == (FiWord) state) {		\
+		if (state->target != (FiWord) state) {		\
 			fiUnwind(state->target, state->value);	\
 		}						\
 		exn = state->value;				\

--- a/aldor/aldor/src/macex.c
+++ b/aldor/aldor/src/macex.c
@@ -109,7 +109,7 @@ macexFiniFile()
 local void
 initMacDef(void)
 {
-	if (!fintMode == FINT_LOOP) macDefs = 0;
+	if (!(fintMode == FINT_LOOP)) macDefs = 0;
 }
  
  

--- a/aldor/aldor/src/macex.c
+++ b/aldor/aldor/src/macex.c
@@ -109,7 +109,7 @@ macexFiniFile()
 local void
 initMacDef(void)
 {
-	if (!(fintMode == FINT_LOOP)) macDefs = 0;
+	if (fintMode != FINT_LOOP) macDefs = 0;
 }
  
  


### PR DESCRIPTION
!somebool == 2 is always false, as !somebool can only be 0 or 1.
changed to the obviously intended comparison.