### PR TITLE
Enable building the compiler on macOS/OS X

### DIFF
--- a/aldor/aldor/src/os_macosx_vm.c
+++ b/aldor/aldor/src/os_macosx_vm.c
@@ -21,8 +21,11 @@
 #include <mach/mach_types.h>
 #include <mach/machine/vm_param.h>
 #include <mach/mach.h>
+#include <mach/mach_vm.h>
 #include <mach/vm_region.h>
 #include <mach/vm_map.h>
+
+#include "util.h"
 
 #define OS_PAGE_SIZE 4096 /* from mach/machine/vm_param.h */
 
@@ -271,8 +274,8 @@ next_os_vm_region(os_vm_region_t region)
 {
     vm_region_basic_info_data_t data ;
     vm_map_t this_task = mach_task_self() ;
-    vm_address_t address = ptrToLong(region->hi) ;
-    vm_size_t    size ;
+    mach_vm_address_t address = ptrToLong(region->hi) ;
+    mach_vm_size_t    size ;
     vm_region_flavor_t flavour = VM_REGION_BASIC_INFO ;
     unsigned int info_count = sizeof(data)/sizeof(int) ;
     mach_port_t object_name ;

--- a/aldor/aldor/src/time.h0
+++ b/aldor/aldor/src/time.h0
@@ -22,7 +22,7 @@ typedef unsigned long time_t;
 #endif  /* !CC_no_time_h */
 
 #ifndef CLK_TCK
-# define CLK_TCK CLOCK_PER_SECOND
+# define CLK_TCK CLOCKS_PER_SEC
 #endif
 
 #endif	/* !_TIME_H0_ */

--- a/aldor/m4/strict_compile.m4
+++ b/aldor/m4/strict_compile.m4
@@ -22,7 +22,8 @@ AC_DEFUN([ALDOR_STRICT_COMPILE],
 	     ;;
        clang*)
              cfgSTRICTCFLAGS="${cfgSTRICTCFLAGS} -fcolor-diagnostics -Wno-error=enum-conversion \
-				-Wno-error=tautological-compare -Wno-parentheses-equality"
+				-Wno-error=tautological-compare -Wno-parentheses-equality \
+				-Wno-error=return-type"
 	     ;;
        *)
              AC_MSG_WARN(Unknown C compiler ${CC})


### PR DESCRIPTION
Update platform related header files to match newer macOS SDK headers.
Add build option to clang to turn off error on no `return`.