### PR TITLE
Error if all flavors of YACC and Lex are missing

### DIFF
--- a/aldor/configure.ac
+++ b/aldor/configure.ac
@@ -15,7 +15,18 @@ AM_MAINTAINER_MODE([enable])
 
 # Checks for programs
 AC_PROG_LEX
+if test "x$LEX" = x:; then
+   AC_MSG_ERROR([[lex/flex not found.
+       	        Please install lex.]])
+fi
 AC_PROG_YACC
+if test x"$YACC" = "xyacc"; then
+     AC_CHECK_PROG([YACC_EXISTS], [yacc], [yes], [no])
+       if test x"$YACC_EXISTS" != xyes; then
+           AC_MSG_ERROR([[bison/byacc/yacc not found.
+       	      Please install bison.]])
+       fi
+fi
 
 GC=aldor
 # Check for GMP


### PR DESCRIPTION
Another possibility would be to include copies of processed files.

However as things stand before this patch. configure will complete but
you'll get a somewhat cryptic message when trying to build.

Fixes #139